### PR TITLE
Use publicKey only when is present on network

### DIFF
--- a/js/controllers/modals/sendTransactionController.js
+++ b/js/controllers/modals/sendTransactionController.js
@@ -210,9 +210,12 @@ angular.module('liskApp').controller('sendTransactionController', ['$scope', 'se
         var data = {
             secret: secretPhrase,
             amount: $scope.convertSHIFT($scope.amount),
-            recipientId: $scope.to,
-            publicKey: userService.publicKey
+            recipientId: $scope.to
         };
+
+	if (userService.publicKey) {
+	    data.publicKey = userService.publicKey;
+	}
 
         if ($scope.secondPassphrase) {
             data.secondSecret = $scope.secondPhrase;


### PR DESCRIPTION
If publicKey is not present on network yet (new account, etc.) we skip that field during API request.
Fixes "Expected type string but found type null" error.
